### PR TITLE
Improve match pattern in replaceCurrentUrlLanguage

### DIFF
--- a/src/SprykerShop/Yves/LanguageSwitcherWidget/Widget/LanguageSwitcherWidget.php
+++ b/src/SprykerShop/Yves/LanguageSwitcherWidget/Widget/LanguageSwitcherWidget.php
@@ -146,7 +146,7 @@ class LanguageSwitcherWidget extends AbstractWidget
      */
     protected function replaceCurrentUrlLanguage(string $currentUrl, array $languages, string $replacementLanguage): string
     {
-        if (preg_match('~/(' . implode('|', $languages) . ')/~', $currentUrl)) {
+        if (preg_match('~^/(' . implode('|', $languages) . ')/?~', $currentUrl)) {
             return preg_replace('~/(' . implode('|', $languages) . ')~', '/' . $replacementLanguage, $currentUrl, 1);
         }
 


### PR DESCRIPTION
We were having a problem in the widget where when there was no ending /, the language switcher would redirect to a 404 non existing page.
For example, when in /de and switching from German to French or Italian, the switcher would output links to /fr/de or /it/de respectively.

The new regex matches /de or /de/ in-distinctively, from the beginning of the url path.