### PR TITLE
Prevent Duplicate Query Parameters in Locale URL Generation

### DIFF
--- a/src/SprykerShop/Yves/LanguageSwitcherWidget/Widget/LanguageSwitcherWidget.php
+++ b/src/SprykerShop/Yves/LanguageSwitcherWidget/Widget/LanguageSwitcherWidget.php
@@ -161,11 +161,15 @@ class LanguageSwitcherWidget extends AbstractWidget
      */
     protected function getLocaleUrlWithQueryString(string $url, ?string $queryString): string
     {
-        if ($queryString) {
-            return $url . '?' . $queryString;
+        if ($queryString === null || str_contains($url, $queryString)) {
+            return $url;
         }
 
-        return $url;
+        $separator = parse_url($url, PHP_URL_QUERY) === null
+            ? static::QUERY_SEPARATOR
+            : static::QUERY_GLUE;
+
+        return sprintf(static::URL_FORMAT, $url, $separator, $queryString);
     }
 
     /**
@@ -209,15 +213,7 @@ class LanguageSwitcherWidget extends AbstractWidget
         $generatedRoute = $this->generateRoute($route, $parameters);
         $this->setRouterLocale($currentLocale);
 
-        if ($queryString === null) {
-            return $generatedRoute;
-        }
-
-        $separator = parse_url($generatedRoute, PHP_URL_QUERY) === null
-            ? static::QUERY_SEPARATOR
-            : static::QUERY_GLUE;
-
-        return sprintf(static::URL_FORMAT, $generatedRoute, $separator, $queryString);
+        return $this->getLocaleUrlWithQueryString($generatedRoute, $queryString);
     }
 
     /**

--- a/tests/SprykerShopTest/Yves/LanguageSwitcherWidget/Widget/LanguageSwitcherWidgetTest.php
+++ b/tests/SprykerShopTest/Yves/LanguageSwitcherWidget/Widget/LanguageSwitcherWidgetTest.php
@@ -110,4 +110,28 @@ class LanguageSwitcherWidgetTest extends Unit
             $this->assertSame(sprintf('%s&%s', $this->tester::TEST_ROUTE_WITH_PARAMS, $this->tester::TEST_QUERY_STRING_2), $url);
         }
     }
+
+    /**
+     * @return void
+     */
+    public function testGetParametersReturnsUrlsWithoutDuplicateQueryParameters(): void
+    {
+        // Arrange
+        $this->tester->request->attributes->set('_route', $this->tester::TEST_ROUTE_WITH_PARAMS);
+        $queryString = parse_url($this->tester::TEST_ROUTE_WITH_PARAMS, PHP_URL_QUERY);
+        $widget = $this->tester->createLanguageSwitcherWidget(
+            $this->tester::HOME_PATH,
+            $queryString,
+            $this->tester->createRequestUri($this->tester::HOME_PATH, $queryString),
+        );
+
+        // Act
+        $parameters = $widget->getParameters();
+
+        // Assert
+        $this->assertArrayHasKey('languages', $parameters);
+        foreach ($parameters['languages'] as $url) {
+            $this->assertSame(1, substr_count($url, $queryString));
+        }
+    }
 }


### PR DESCRIPTION
## PR Description
This PR adjusts the logic for locale-based URL generation to prevent duplication of query parameters. Previously, URLs could include the same parameter multiple times, which caused inconsistencies in routing.

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
